### PR TITLE
Feature/minor upgrades

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Use the lowest ubuntu version to guarantee backwards compatibility with GLIBC
+        os: [ubuntu-18.04, macos-latest, windows-latest]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,19 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      # see: https://github.community/t/how-to-get-just-the-tag-name/16241/7
+      - name: Get the version
+        id: get_version
+        shell: bash
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Set global variables
+        shell: bash
+        run: |
+          echo "VERSION=${{ steps.get_version.outputs.VERSION}}" >> $GITHUB_ENV
+          echo "FINDENT_ROOT=${{ github.workspace }}/findent-4.1.1" >> $GITHUB_ENV
+          echo "INSTALL_ROOT=${{ github.workspace }}/build/${{ runner.os }}" >> $GITHUB_ENV
+
       # Downloads findent tar.gz from sourceforge
       # TODO: Delete when github repo is updated
       - name: Download and Extract findent from fixed release
@@ -52,17 +65,17 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
             cd findent-4.1.1
-            ./configure --prefix=${GITHUB_WORKSPACE}/build/Linux
+            ./configure --prefix=${INSTALL_ROOT}
             make -j2
             make install
           elif [ "$RUNNER_OS" == "macOS" ]; then
             cd findent-4.1.1
-            ./configure --prefix=${GITHUB_WORKSPACE}/build/MacOSX CC=clang CXX=clang++
+            ./configure --prefix=${INSTALL_ROOT} CC=clang CXX=clang++
             make -j2
             make install
           elif [ "$RUNNER_OS" == "Windows" ]; then
             cd findent-4.1.1
-            ./configure --prefix=${GITHUB_WORKSPACE}/build/Windows --with-windows MINGW32=g++
+            ./configure --prefix=${INSTALL_ROOT} --with-windows MINGW32=g++
             make -j2
             make install
           else
@@ -80,20 +93,25 @@ jobs:
       - name: Build Python wheels
         shell: bash
         run: |
-          echo "Tag/Branch: " $GITHUB_REF
-          echo "git SHA: " $GITHUB_SHA
+          echo "Branch:" $GITHUB_REF
+          echo "git SHA:" $GITHUB_SHA
+          echo "Version:" ${VERSION}
+          echo "INSTALL_ROOT:" ${INSTALL_ROOT}
+          echo "FINDENT_ROOT:" ${FINDENT_ROOT}
+
           if [ "$RUNNER_OS" == "Linux" ]; then
             pip3 install setuptools wheel
-            INSTALL_ROOT=${GITHUB_WORKSPACE}/build/Linux FINDENT_ROOT=${GITHUB_WORKSPACE}/findent-4.1.1 python3 setup-wheel.py build bdist_wheel --plat-name manylinux1_x86_64 --universal
+            python3 setup-wheel.py build bdist_wheel --plat-name manylinux1_x86_64 --universal
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            INSTALL_ROOT=${GITHUB_WORKSPACE}/build/MacOSX FINDENT_ROOT=${GITHUB_WORKSPACE}/findent-4.1.1 python3 setup-wheel.py build bdist_wheel --plat-name macosx_10_15_x86_64 --universal
+            python3 setup-wheel.py build bdist_wheel --plat-name macosx_10_15_x86_64 --universal
           elif [ "$RUNNER_OS" == "Windows" ]; then
             pip install setuptools wheel
-            INSTALL_ROOT=${GITHUB_WORKSPACE}/build/Windows FINDENT_ROOT=${GITHUB_WORKSPACE}/findent-4.1.1 python3 setup-wheel.py build bdist_wheel --plat-name win_amd64 --universal
+            python3 setup-wheel.py build bdist_wheel --plat-name win_amd64 --universal
           else
             echo "$RUNNER_OS not supported"
             exit 1
           fi
+
 
       # Save dist/ directory to persist for the next job "publish"
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,13 @@ jobs:
           name: python-wheels
           path: dist
 
+      # This for wfindent to work on MacOS
+      # XXX: remove when wfindent stops using getopt
+      - name: Install gnu-getopt for Mac
+        shell: bash
+        if: ${{ runner.os == 'macOS' }}
+        run: brew install gnu-getopt
+
       - name: Install Python wheels
         working-directory: dist
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,11 +80,15 @@ jobs:
       - name: Build Python wheels
         shell: bash
         run: |
+          echo "Tag/Branch: " $GITHUB_REF
+          echo "git SHA: " $GITHUB_SHA
           if [ "$RUNNER_OS" == "Linux" ]; then
+            pip3 install setuptools wheel
             INSTALL_ROOT=${GITHUB_WORKSPACE}/build/Linux FINDENT_ROOT=${GITHUB_WORKSPACE}/findent-4.1.1 python3 setup-wheel.py build bdist_wheel --plat-name manylinux1_x86_64 --universal
           elif [ "$RUNNER_OS" == "macOS" ]; then
             INSTALL_ROOT=${GITHUB_WORKSPACE}/build/MacOSX FINDENT_ROOT=${GITHUB_WORKSPACE}/findent-4.1.1 python3 setup-wheel.py build bdist_wheel --plat-name macosx_10_15_x86_64 --universal
           elif [ "$RUNNER_OS" == "Windows" ]; then
+            pip install setuptools wheel
             INSTALL_ROOT=${GITHUB_WORKSPACE}/build/Windows FINDENT_ROOT=${GITHUB_WORKSPACE}/findent-4.1.1 python3 setup-wheel.py build bdist_wheel --plat-name win_amd64 --universal
           else
             echo "$RUNNER_OS not supported"
@@ -97,8 +101,58 @@ jobs:
           name: python-wheels
           path: dist
 
-  publish:
+  test_python_wheels:
     needs: build
+    # Run on Ubuntu, Windows and Mac OS
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11, windows-latest]
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      # - uses: actions/setup-python@v2
+      #   with:
+      #     python-version: "3.x"
+      - uses: actions/download-artifact@v2
+        with:
+          name: python-wheels
+          path: dist
+
+      - name: Install Python wheels
+        working-directory: dist
+        shell: bash
+        run: |
+          pip install --user --upgrade --force-reinstall pip
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            pip install --target=${GITHUB_WORKSPACE}/pip-bin *manylinux1_x86_64*
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            pip install --target=${GITHUB_WORKSPACE}/pip-bin *macosx_10_15_x86_64*
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+            pip install --target=${GITHUB_WORKSPACE}/pip-bin *win_amd64*
+          else
+            echo "$RUNNER_OS not supported"
+            exit 1
+          fi
+
+      - name: Test findent
+        working-directory: pip-bin
+        shell: bash
+        run: |
+          ls -Ra .
+          ./bin/findent -h
+
+      - name: Test wfindent
+        working-directory: pip-bin
+        shell: bash
+        run: |
+          export PATH=${GITHUB_WORKSPACE}/pip-bin/bin:${PATH}
+          ./bin/wfindent -h
+
+  # TODO: move to a separate .yml and use that badge in README
+  publish:
+    needs: [build, test_python_wheels]
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,6 @@ jobs:
           elif [ "$RUNNER_OS" == "macOS" ]; then
             INSTALL_ROOT=${GITHUB_WORKSPACE}/build/MacOSX FINDENT_ROOT=${GITHUB_WORKSPACE}/findent-4.1.1 python3 setup-wheel.py build bdist_wheel --plat-name macosx_10_15_x86_64 --universal
           elif [ "$RUNNER_OS" == "Windows" ]; then
-            pip install setuptools wheel
             INSTALL_ROOT=${GITHUB_WORKSPACE}/build/Windows FINDENT_ROOT=${GITHUB_WORKSPACE}/findent-4.1.1 python3 setup-wheel.py build bdist_wheel --plat-name win_amd64 --universal
           else
             echo "$RUNNER_OS not supported"

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,98 @@
+[![PyPI Latest Release](https://img.shields.io/pypi/v/findent.svg)](https://pypi.org/project/findent/)
+[![PyPi release](https://github.com/gnikit/findent-pypi/actions/workflows/main.yml/badge.svg)](https://github.com/gnikit/findent-pypi/actions/workflows/main.yml)
+
+# findent: powerful Fortran formatter
+
+## What is it?
+
+**findent** indents/beautifies/converts and can optionally generate the dependencies of Fortran sources.
+
+## Features
+
+- Supports Fortran-66 up to Fortran-2018
+- Converts from Fixed Form to Free Form and vice-versa
+- Honours `cpp` and `coco` preprocess statements
+- Honours OpenMP conditionals
+- Validated against all constructs in
+'Modern Fortran explained, Incorporating Fortran 2018, Metcalf e.a.'
+- Supported platformrs: Unix and Windows
+- High speed: 50K - 100K lines per second
+- Provides wrapper `wfindent` (`wfindent.bat` on Windows) for batch file processing
+- vim, gedit, emacs: findent optionally emits configuration files
+for these editors to use findent as a plugin.
+- GUI frontent available in a separate package: `jfindent`
+
+## Examples
+
+### Format file `in.f90` to `out.f90`
+
+```sh
+findent < in.f90 > out.f90
+```
+
+### Format with 4-space indentation and convert Fixed Form `in.f` to Free Form `out.f90`
+
+```sh
+findent -i4 -Rr < in.f > out.f90
+```
+
+### Format and refactor all files with `.f` extension in the current directory
+
+```sh
+wfindent -i4 -Rr *.f
+```
+
+### Generating Fortran source dependencies for use in Makefile
+
+**findent** will generate a dependency list for:
+
+- definitions and uses of modules and submodules
+- `include`, `#include` and `??include` statements
+
+In your Makefile add something similar to:
+
+```Makefile
+findent --makefdeps > makefdeps
+chmod +x makefdeps
+
+include deps
+dep deps:
+  ./makefdeps *.f90 > deps
+```
+
+The flag `--makefdeps` generates a script in the standard output.
+Depending on your usecase the script might not suffice and you will need to write your own version.
+
+## Editor incorporation
+
+### (G) VIM users
+
+Installation instructions:
+
+```sh
+findent --vim_help
+```
+
+Documentation:
+
+`:help equalprg`
+
+`:help indentexpr`
+<!-- - vim/README -->
+<!-- - and the comments in the files vim/findent.vim and vim/fortran.vim -->
+
+### GEDIT users
+
+Installation instructions:
+
+```sh
+findent --gedit_help
+```
+
+### EMACS users
+
+Installation instructions:
+
+```sh
+findent --emacs_help
+```

--- a/setup-wheel.py
+++ b/setup-wheel.py
@@ -2,21 +2,14 @@ import os
 import glob
 import setuptools
 
-# Build specific variables should be overwritten by the build system
-# Use GITHUB_REF and/or GITHUB_SHA
-# https://docs.github.com/en/actions/learn-github-actions/environment-variables
-MAJOR_VERSION = 4
-MINOR_VERSION = 1
-PATCH_VERSION = 1
-
-version = f"{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}"
 name = "findent"
 
 ################################################################################
 FINDENT_ROOT = os.environ["FINDENT_ROOT"]
 INSTALL_ROOT = os.environ["INSTALL_ROOT"]
+VERSION = os.environ["VERSION"]
 
-print("VERSION: ", version)
+print("VERSION: ", VERSION)
 print("FINDENT_ROOT: ", FINDENT_ROOT)
 print("INSTALL_ROOT: ", INSTALL_ROOT)
 ################################################################################
@@ -26,7 +19,7 @@ data_files = [("bin", exes)]
 
 setuptools.setup(
     name=name,
-    version=version,
+    version=VERSION,
     description="findent: powerful Fortran formatter",
     long_description=open(os.path.join(os.getcwd(), "doc/README.md"), "r").read(),
     long_description_content_type="text/markdown",

--- a/setup-wheel.py
+++ b/setup-wheel.py
@@ -69,6 +69,6 @@ setuptools.setup(
         "Topic :: Software Development",
         "Topic :: Text Processing",
     ],
-    package_dir={"": os.path.join(os.getcwd() + "/build")},
+    install_requires=["setuptools", "wheel"],
     data_files=data_files,
 )

--- a/setup-wheel.py
+++ b/setup-wheel.py
@@ -46,8 +46,8 @@ data_files = [("bin", exes)]
 setuptools.setup(
     name=name,
     version=version,
-    description="findent Fortran formatter test python wrapper",
-    long_description=open(os.path.join(FINDENT_ROOT, "doc/README"), "r").read(),
+    description="findent: powerful Fortran formatter",
+    long_description=open(os.path.join(os.getcwd(), "doc/README.md"), "r").read(),
     long_description_content_type="text/markdown",
     author="Willem Vermin",
     # author_email="wvermin@gmail.com",

--- a/setup-wheel.py
+++ b/setup-wheel.py
@@ -1,7 +1,10 @@
 import os
+import glob
 import setuptools
 
 # Build specific variables should be overwritten by the build system
+# Use GITHUB_REF and/or GITHUB_SHA
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables
 MAJOR_VERSION = 4
 MINOR_VERSION = 1
 PATCH_VERSION = 1
@@ -18,30 +21,8 @@ print("FINDENT_ROOT: ", FINDENT_ROOT)
 print("INSTALL_ROOT: ", INSTALL_ROOT)
 ################################################################################
 
-# If built with Windows
-if os.name == "nt":
-    exes = [
-        os.path.join(INSTALL_ROOT, "bin", "findent.exe"),
-        os.path.join(INSTALL_ROOT, "bin", "wfindent"),
-    ]
-# POSIX OSs
-else:
-    exes = [
-        os.path.join(INSTALL_ROOT, "bin", "findent"),
-        os.path.join(INSTALL_ROOT, "bin", "wfindent"),
-    ]
-
-
-def gen_install_list(subdir):
-    for dirpath, dirs, files in os.walk(subdir):
-        if len(files) != 0:
-            filepaths = [os.path.join(dirpath, f) for f in files]
-            relpath = os.path.relpath(dirpath, INSTALL_ROOT)
-            data_files.append((relpath, filepaths))
-
-
+exes = glob.glob(os.path.join(INSTALL_ROOT, "bin/*"))
 data_files = [("bin", exes)]
-# gen_install_list(INSTALL_ROOT + "/share")
 
 setuptools.setup(
     name=name,
@@ -69,6 +50,6 @@ setuptools.setup(
         "Topic :: Software Development",
         "Topic :: Text Processing",
     ],
-    install_requires=["setuptools", "wheel"],
+    package_dir={"": os.path.join(os.getcwd(), "build")},
     data_files=data_files,
 )


### PR DESCRIPTION
Makes a few minor changes

## Changes

- Captures binaries with globs
- Adds testing of generated wheels, albeit minimal
- Adds dependencies for setuptools and wheel which some Python environments do not have by default
- Changes the default Ubuntu distro to 18.04 for backwards libc compatibility
- Adds a more appropriate README to the PyPi package
- Fixed the short description of the PyPi package
- Automates versioning semantics


## Note:

Changes related to PyPi will take effect with the new findent release