### PR TITLE
ci: update upload and download GH Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,9 +34,9 @@ jobs:
           python -m pip install wheel>=0.40.0
           wheel tags --python-tag py3 --abi-tag none --remove ./wheelhouse/*.whl
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-${{ matrix.sys.os }}
           path: ./wheelhouse/*.whl
 
   publish:
@@ -45,10 +45,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: python-wheels
+          pattern: python-wheels*
           path: dist
+          merge-multiple: true
 
       - name: Publish package
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
v4 of the upload GH Action introduced breaking changes. This PR addresses them.